### PR TITLE
Update footer copyright year to 2026

### DIFF
--- a/about.html
+++ b/about.html
@@ -384,7 +384,7 @@
 </div>
 
 <div class="footer">
-  © 2025 Suzanne O'Shea
+  © 2026 Suzanne O'Shea
 </div>
 
 <script>

--- a/index.html
+++ b/index.html
@@ -963,7 +963,7 @@
     </div>
 
     <div class="footer">
-      © 2025 Suzanne O'Shea
+      © 2026 Suzanne O'Shea
     </div>
 
     <script>


### PR DESCRIPTION
### Motivation
- Bring the site footer up to date by changing the displayed copyright year from 2025 to 2026.

### Description
- Replaced `© 2025 Suzanne O'Shea` with `© 2026 Suzanne O'Shea` in `index.html` and `about.html`.

### Testing
- Searched for occurrences with `rg -n "2025|copyright|©|footer" .` and verified the change with `git diff -- index.html about.html`; the diff and commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5702a95483338b6339353d50e49c)