### PR TITLE
Fix slideshow markup so Mouth Full of Matches renders correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -852,6 +852,7 @@
             </svg>
           </button>
         </div>
+      </div>
 
         <div class="slide">
           <div class="zoom-container">
@@ -927,32 +928,6 @@
           </div>
         </div>
 
-        <<<<<<< HEAD=======<div class="slide">
-          <div class="zoom-container">
-            <img loading="lazy" src="assets/images/MouthfulOfMatches.jpg" alt="Mouth Full of Matches" />
-          </div>
-          <div class="slide-info">
-            <h2 class="art-title">Mouth Full of Matches</h2>
-            <p class="artist">by Suzanne O'Shea</p>
-            <p class="art-description">
-              Arms crossed and gaze unwavering, the figure stands within layers of heat, shadow, and fractured light.
-              A Mouth Full of Matches evokes what remains after ignition, not destruction, but endurance. Vivid reds and
-              smoky textures suggest a woman shaped by intensity, holding both vulnerability and defiant presence.
-            </p>
-            <div class="art-details">
-              <p class="art-dimensions">24" x 18"</p>
-              <p class="art-medium">Mixed Media</p>
-            </div>
-            <button class="play-audio" style="visibility: hidden;" aria-label="Play audio">
-              <svg width="18" height="18" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-                <circle cx="24" cy="24" r="22" stroke="black" stroke-width="2" fill="white" />
-                <polygon points="18,14 34,24 18,34" fill="black" />
-              </svg>
-            </button>
-          </div>
-      </div>
-
-      >>>>>>> origin/main
       <div class="slideshow-nav">
         <button id="prevBtn" class="btn-prev" type="button">Prev</button>
         <button id="nextBtn" class="btn-next" type="button">Next</button>


### PR DESCRIPTION
### Motivation
- The slideshow had malformed HTML from an unresolved merge conflict around the `Mouth Full of Matches` slide, which can break gallery controls and make artwork-specific buttons never appear. 
- The `Mouth Full of Matches` slide's audio control is also explicitly hidden via inline `style="visibility: hidden;"`, which explains why that control never shows even after markup is fixed.

### Description
- Removed unresolved merge conflict markers and the duplicate conflicting slide block from `index.html`.
- Restored the missing closing `</div>` for the `Mouth Full of Matches` slide so slide nesting is valid.
- Cleaned up surrounding slideshow structure so subsequent slides render normally.

### Testing
- Verified no conflict markers remain using `rg -n "<<<<<<<|=======|>>>>>>>"` on `index.html` and confirmed the search returned no results. 
- Inspected the `Mouth Full of Matches` slide block in `index.html` to confirm the closing `</div>` was restored and the slide is no longer nested incorrectly. 
- Ran a project-wide search for the artwork title to confirm only the intended slide remains and layout around it is consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe59a883288333b79c8841446619c8)