### PR TITLE
Restore legacy mobile share button styling and placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -746,10 +746,64 @@
       animation: fadeIn 0.5s 0.3s forwards;
     }
 
-    .mobile-share-btn { position: absolute; right: 14px; bottom: 14px; z-index: 25; padding: 8px 12px; border-radius: 999px; border: 1px solid rgba(255,255,255,.35); background: rgba(0,0,0,.45); color: #f4f4f4; font-size: 11px; letter-spacing: .08em; text-transform: uppercase; opacity: 0; pointer-events: none; transform: translateY(8px); transition: opacity .25s ease, transform .25s ease; }
-    .mobile-share-btn.visible { opacity: 1; pointer-events: auto; transform: translateY(0); }
-    .share-toast { position: fixed; left: 50%; bottom: 22px; transform: translateX(-50%) translateY(12px); background: rgba(0,0,0,.75); color: #fff; font-size: 12px; padding: 8px 12px; border-radius: 999px; opacity: 0; pointer-events: none; transition: opacity .2s ease, transform .2s ease; z-index: 2000; }
-    .share-toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+    .mobile-share-btn {
+      position: absolute;
+      bottom: 8vh;
+      left: 50%;
+      transform: translateX(-50%);
+      background: rgba(23, 23, 23, 0.9);
+      color: #ececec;
+      border: 1px solid #36383a;
+      padding: 0.6rem 1rem;
+      border-radius: 20px;
+      font-size: 0.8rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      z-index: 2002;
+      font-family: 'Inter', sans-serif;
+      font-weight: 300;
+      opacity: 0;
+      visibility: hidden;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+    }
+
+    .mobile-share-btn svg {
+      display: block;
+    }
+
+    .mobile-share-btn.visible {
+      opacity: 1;
+      visibility: visible;
+      pointer-events: auto;
+      transform: translateX(-50%);
+    }
+
+    .share-toast {
+      position: fixed;
+      bottom: 12vh;
+      left: 50%;
+      transform: translate(-50%, 0);
+      background: rgba(23, 23, 23, 0.95);
+      color: #ececec;
+      border: 1px solid #36383a;
+      border-radius: 999px;
+      padding: 0.55rem 0.9rem;
+      font-size: 0.75rem;
+      font-family: 'Inter', sans-serif;
+      font-weight: 300;
+      letter-spacing: 0.03em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.25s ease, transform 0.25s ease;
+      z-index: 2003;
+    }
+
+    .share-toast.show {
+      opacity: 1;
+      transform: translate(-50%, -8px);
+    }
   </style>
 </head>
 
@@ -1506,8 +1560,14 @@
         shareBtn.type = 'button';
         shareBtn.className = 'mobile-share-btn';
         shareBtn.setAttribute('aria-label', 'Share this artwork');
-        shareBtn.textContent = 'Share';
+        shareBtn.innerHTML = `
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 3l4 4m0 0l-4 4m4-4H7a4 4 0 00-4 4v7" stroke="#afafaf" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          Share`;
         shareBtn.addEventListener('click', async (e) => { e.stopPropagation(); await handleShare(); });
+        shareBtn.addEventListener('touchstart', (e) => { e.stopPropagation(); });
+        shareBtn.addEventListener('touchend', (e) => { e.stopPropagation(); });
       }
       function attachShareButtonTo(slide) { ensureShareButton(); const z = slide.querySelector('.zoom-container'); if (z && shareBtn.parentElement !== z) z.appendChild(shareBtn); }
       function getIsZoomed(img) { const t = window.getComputedStyle(img).transform; return t && t !== 'none' && t !== 'matrix(1, 0, 0, 1, 0, 0)'; }


### PR DESCRIPTION
### Motivation
- The mobile share button was appearing in the wrong position and using a newer pill-style visual that broke the intended legacy mobile UX, so the legacy placement and styling were restored.
- The share toast needed to match the legacy visual treatment so feedback aligns with the restored button appearance.

### Description
- Replaced the recent bottom-right pill CSS with the legacy centered-bottom styling and layout for `.mobile-share-btn` and adjusted `.share-toast` to the previous visual (position, sizing, typography, border and z-index changes). 
- Restored the button markup to include the original SVG icon plus the `Share` label instead of plain text, and updated the button to use `innerHTML` for that content.
- Added touch event handlers (`touchstart` / `touchend`) on the share button to stop propagation on mobile and preserve previous interaction behavior.
- Kept the existing JS visibility/timing helpers (`ensureShareButton`, `attachShareButtonTo`, `updateShareButtonVisibility`, `handleShare`) and updated their markup/DOM changes to use the restored styling.

### Testing
- No automated tests were run because this is a visual/CSS and DOM behavior change only; verification was performed by reviewing the `git diff` and committing the file changes with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5dffe41c8333bc5cf2e0889a048b)