### PR TITLE
Fix artwork sharing payload to avoid generic “You're Invited” cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1583,10 +1583,50 @@
         shareToast.textContent = message; shareToast.classList.add('show'); clearTimeout(shareToastTimer); shareToastTimer = setTimeout(() => shareToast.classList.remove('show'), 2000);
       }
       async function handleShare() {
-        const s = document.querySelector('.slide.full-screen'); if (!s) return;
+        const s = document.querySelector('.slide.full-screen');
+        if (!s) return;
+
         const title = s.querySelector('.art-title')?.textContent?.trim() || 'Artwork';
+        const imageEl = s.querySelector('img');
         const link = new URL(window.location.pathname + '?art=' + encodeURIComponent(slugify(title)), window.location.origin).href;
-        await navigator.clipboard.writeText(link); showShareFeedback('Link copied to clipboard');
+
+        try {
+          if (navigator.share) {
+            const shareData = {
+              title,
+              text: title,
+              url: link
+            };
+
+            const imageSrc = imageEl?.currentSrc || imageEl?.src;
+            if (imageSrc && navigator.canShare) {
+              try {
+                const resp = await fetch(imageSrc, { mode: 'cors' });
+                if (resp.ok) {
+                  const blob = await resp.blob();
+                  const ext = (blob.type.split('/')[1] || 'jpg').replace('jpeg', 'jpg');
+                  const safeName = slugify(title) || 'artwork';
+                  const file = new File([blob], `${safeName}.${ext}`, { type: blob.type || 'image/jpeg' });
+
+                  if (navigator.canShare({ files: [file] })) {
+                    shareData.files = [file];
+                  }
+                }
+              } catch (_) {
+                // Ignore image-fetch errors and fall back to URL-only share.
+              }
+            }
+
+            await navigator.share(shareData);
+            showShareFeedback('Artwork shared');
+            return;
+          }
+        } catch (err) {
+          if (err && err.name === 'AbortError') return;
+        }
+
+        await navigator.clipboard.writeText(link);
+        showShareFeedback('Link copied to clipboard');
       }
 
       if (window.innerWidth < 768) {


### PR DESCRIPTION
### Motivation
- The mobile share action was only copying the homepage URL, causing recipients to see the generic homepage Open Graph card ("You're Invited") instead of the specific artwork.
- The goal is to provide artwork-specific metadata and a preview so share targets render the correct title and image.

### Description
- Updated `handleShare()` in `index.html` to prefer the Web Share API and include artwork-specific `title`, `text`, and a deep link `?art=<slug>` in the share payload.
- Added logic to locate the current slide image, fetch it, convert it to a `File`, and attach it to `shareData` when `navigator.canShare({ files })` permits file sharing.
- Implemented graceful fallbacks so if native sharing or image attach fails the code falls back to URL-only share and finally to copying the deep link to the clipboard.
- Added handling to ignore user-cancel `AbortError` from the share flow to avoid noisy errors.

### Testing
- Inspected the resulting diff for `index.html` to confirm the new share logic was applied (image attachment and Web Share API integration); verification succeeded.
- Performed repository operations to stage the change and create the pull request; those operations completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5ffdfbc48333867f224ef8f6e780)