### PR TITLE
Fix share button to share direct artwork image link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1588,34 +1588,15 @@
 
         const title = s.querySelector('.art-title')?.textContent?.trim() || 'Artwork';
         const imageEl = s.querySelector('img');
-        const link = new URL(window.location.pathname + '?art=' + encodeURIComponent(slugify(title)), window.location.origin).href;
+        const imageSrc = imageEl?.currentSrc || imageEl?.src;
+        const link = imageSrc ? new URL(imageSrc, window.location.origin).href : window.location.href;
 
         try {
           if (navigator.share) {
             const shareData = {
               title,
-              text: title,
               url: link
             };
-
-            const imageSrc = imageEl?.currentSrc || imageEl?.src;
-            if (imageSrc && navigator.canShare) {
-              try {
-                const resp = await fetch(imageSrc, { mode: 'cors' });
-                if (resp.ok) {
-                  const blob = await resp.blob();
-                  const ext = (blob.type.split('/')[1] || 'jpg').replace('jpeg', 'jpg');
-                  const safeName = slugify(title) || 'artwork';
-                  const file = new File([blob], `${safeName}.${ext}`, { type: blob.type || 'image/jpeg' });
-
-                  if (navigator.canShare({ files: [file] })) {
-                    shareData.files = [file];
-                  }
-                }
-              } catch (_) {
-                // Ignore image-fetch errors and fall back to URL-only share.
-              }
-            }
 
             await navigator.share(shareData);
             showShareFeedback('Artwork shared');


### PR DESCRIPTION
### Motivation
- Sharing currently built a page URL (`?art=`) and attached text/files which resulted in the main site preview being used instead of the image-specific preview.
- The goal is to ensure shares (and the clipboard fallback) publish a direct absolute URL to the artwork image so Twitter/OG/tile previews match the image itself.

### Description
- Changed the mobile share handler in `index.html` to compute `imageSrc` from `imageEl.currentSrc || imageEl.src` and use that as the shared `url` instead of building a page URL with `?art=`.
- Removed the extra `text` field and the image fetch/file-attachment flow so `navigator.share` only receives `title` and the direct image `url`.
- Updated the clipboard fallback to copy the same direct image URL.

### Testing
- Located and inspected the share handler with `rg` and `sed`/`nl` to verify the targeted changes were applied successfully.
- Performed a commit documenting the change using `git commit` which completed successfully.
- No automated unit or runtime tests existed in the repository and none were executed; changes were validated via code inspection and local VCS checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe62213a808333b97c6e3e62bafa1f)