### PR TITLE
Share uses artwork title and canonical slide URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -1587,15 +1587,16 @@
         if (!s) return;
 
         const title = s.querySelector('.art-title')?.textContent?.trim() || 'Artwork';
-        const imageEl = s.querySelector('img');
-        const imageSrc = imageEl?.currentSrc || imageEl?.src;
-        const link = imageSrc ? new URL(imageSrc, window.location.origin).href : window.location.href;
+        const artworkSlug = slugify(title);
+        const shareUrl = new URL(window.location.href);
+        shareUrl.searchParams.set('art', artworkSlug);
 
         try {
           if (navigator.share) {
             const shareData = {
               title,
-              url: link
+              text: title,
+              url: shareUrl.href
             };
 
             await navigator.share(shareData);
@@ -1606,7 +1607,7 @@
           if (err && err.name === 'AbortError') return;
         }
 
-        await navigator.clipboard.writeText(link);
+        await navigator.clipboard.writeText(shareUrl.href);
         showShareFeedback('Link copied to clipboard');
       }
 


### PR DESCRIPTION
### Motivation
- Sharing used the raw image asset URL which caused receivers to display the image filename instead of the slide title. 
- Shares that pointed at the image asset did not resolve to the exhibition slide (e.g., `Mouth Full of Matches`) so recipients couldn't open the artwork in context.

### Description
- Updated `handleShare()` in `index.html` to derive `title` from the slide `.art-title` and build a canonical slide URL by adding `?art=<slug>` using `slugify(title)`.
- Added `text: title` to the Web Share payload so share targets explicitly receive the artwork title.
- Replaced the clipboard fallback to copy the canonical slide URL (`shareUrl.href`) instead of the raw image URL.
- Kept share button attachment and visibility logic intact while ensuring the shared link resolves back to the slide context.

### Testing
- Performed static verification with `rg` searches to locate share and slide code and confirmed the modified block is in `index.html` which succeeded.
- Inspected relevant file ranges with `sed -n` and reviewed the diff with `git diff` which succeeded.
- Committed the change with `git commit` which succeeded and recorded the change message `Fix mobile share payload to use artwork title and slide URL`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe63bad0b08333a54b820ea9b08a42)