### PR TITLE
Fix share payload and social preview titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" integrity="sha512-..."
     crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-  <meta property="og:title" content="You're Invited" />
+  <meta property="og:title" content="Virtual Exhibition" />
   <meta property="og:description" content="Virtual Exhibition" />
   <meta property="og:url" content="https://suzanneoshea.art/" />
   <meta property="og:image" content="https://suzanneoshea.art/assets/images/thumbnail.png" />
@@ -36,7 +36,7 @@
   <link rel="apple-touch-icon" href="https://suzanneoshea.art/assets/images/thumbnail.png" />
 
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="You're Invited" />
+  <meta name="twitter:title" content="Virtual Exhibition" />
   <meta name="twitter:description" content="Virtual Exhibition" />
   <meta name="twitter:image" content="https://suzanneoshea.art/assets/images/thumbnail.png" />
   <meta name="twitter:image:alt" content="Suzanne O'Shea exhibition preview" />
@@ -1594,8 +1594,8 @@
         try {
           if (navigator.share) {
             const shareData = {
-              title,
-              text: title,
+              title: 'Virtual Exhibition',
+              text: 'Virtual Exhibition',
               url: shareUrl.href
             };
 


### PR DESCRIPTION
### Motivation
- The mobile share sheet was sending the active artwork title (resulting in previews like “You’re Invited”) instead of the consistent exhibition label, and social link previews needed to match the intended wording.

### Description
- Updated Open Graph `og:title` and Twitter `twitter:title` in `index.html` to `Virtual Exhibition`.
- Overrode the Web Share API payload to set `title` and `text` to `'Virtual Exhibition'` while preserving the artwork-specific URL parameter (`?art=...`).
- Applied the string replacements directly in `index.html` so preview text and share behavior are consistent across platforms.

### Testing
- Located and verified occurrences with `rg` and inspected the changed lines with `nl`, which showed the old and updated values as expected (succeeded).
- Confirmed the HTML patch with `git diff` to ensure the meta tags and `navigator.share` payload were updated (succeeded).
- Ran the PR creation tool `make_pr` to record the change; the tool completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe650fcf3c83338ba864186fe1bdc1)