### PR TITLE
Share fullscreen artwork image and title (iMessage-friendly)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1588,15 +1588,20 @@
 
         const title = s.querySelector('.art-title')?.textContent?.trim() || 'Artwork';
         const artworkSlug = slugify(title);
-        const shareUrl = new URL(window.location.href);
-        shareUrl.searchParams.set('art', artworkSlug);
+
+        const imageEl = s.querySelector('.zoom-container img');
+        const imageSrc = imageEl?.getAttribute('src');
+        if (!imageSrc) return;
+
+        const imageUrl = new URL(imageSrc, window.location.origin);
+        imageUrl.hash = artworkSlug;
 
         try {
           if (navigator.share) {
             const shareData = {
-              title: 'Virtual Exhibition',
-              text: 'Virtual Exhibition',
-              url: shareUrl.href
+              title,
+              text: title,
+              url: imageUrl.href
             };
 
             await navigator.share(shareData);
@@ -1607,7 +1612,8 @@
           if (err && err.name === 'AbortError') return;
         }
 
-        await navigator.clipboard.writeText(shareUrl.href);
+        await navigator.clipboard.writeText(`${title}
+${imageUrl.href}`);
         showShareFeedback('Link copied to clipboard');
       }
 


### PR DESCRIPTION
### Motivation
- When sharing from the fullscreen slide on mobile the link and preview pointed to the exhibition root instead of the specific artwork image, causing iMessage to show the wrong preview and title. 
- The goal is to make the shared message point to the exact slide image and use the slide title so recipients see the image preview and correct title.

### Description
- Updated `handleShare` in `index.html` to select the current slide image (`.zoom-container img`) and build an `imageUrl` relative to `window.location.origin` instead of using the page URL. 
- Appended the artwork slug as a hash on the `imageUrl` (`imageUrl.hash = artworkSlug`) for stable title/deep-link context. 
- Set the native share payload `title` and `text` to the active slide title and `url` to `imageUrl.href` so iMessage receives the artwork title and image URL. 
- Changed the clipboard fallback to copy both the artwork `title` and the `imageUrl.href` on failure of the native share path, and return early if no image source is found.

### Testing
- Ran a static search to confirm the `handleShare` block was updated to reference the image element and `imageUrl` construction, and inspected the diff to verify the inserted lines; this check passed. 
- Performed a local share flow verification in a browser (tested the `navigator.share` path and the clipboard fallback) to confirm the shared payload contains the slide `title` and the image URL; both paths succeeded. 
- No automated unit tests exist for this UI share flow in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe66f7d9f083338d9fe0959f8c6586)