### PR TITLE
Fix mobile share content and deep-link URL format

### DIFF
--- a/index.html
+++ b/index.html
@@ -1589,19 +1589,15 @@
         const title = s.querySelector('.art-title')?.textContent?.trim() || 'Artwork';
         const artworkSlug = slugify(title);
 
-        const imageEl = s.querySelector('.zoom-container img');
-        const imageSrc = imageEl?.getAttribute('src');
-        if (!imageSrc) return;
-
-        const imageUrl = new URL(imageSrc, window.location.origin);
-        imageUrl.hash = artworkSlug;
+        const shareUrl = new URL(window.location.href);
+        shareUrl.searchParams.set('art', artworkSlug);
+        shareUrl.hash = '';
 
         try {
           if (navigator.share) {
             const shareData = {
               title,
-              text: title,
-              url: imageUrl.href
+              url: shareUrl.href
             };
 
             await navigator.share(shareData);
@@ -1612,8 +1608,7 @@
           if (err && err.name === 'AbortError') return;
         }
 
-        await navigator.clipboard.writeText(`${title}
-${imageUrl.href}`);
+        await navigator.clipboard.writeText(shareUrl.href);
         showShareFeedback('Link copied to clipboard');
       }
 


### PR DESCRIPTION
### Motivation
- Prevent iMessage from inserting the slide title as separate plain text when sharing from mobile. 
- Ensure shared links reference the gallery slide context instead of the raw image filename URL. 
- Provide a consistent clipboard fallback that only copies the deep-link URL.

### Description
- Build a deep link using the current page URL with `?art=<slug>` by setting `searchParams` on `window.location.href` and clearing `hash`. 
- Remove the `text` field from the `navigator.share` payload so only the `title` and `url` are shared. 
- Change the clipboard fallback to copy only the generated share URL (removed the separate `title`+newline + image URL copy). 
- Continue to use the existing `slugify` of the slide title so the `art` param targets the correct slide.

### Testing
- Ran repository searches and file inspections with `rg` and `sed` to verify the modified code locations and content, which completed successfully. 
- Verified the code diff with `git diff -- index.html` and reviewed the changes, which succeeded. 
- Committed the change with `git commit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe690518e8833382175f3b1bfe825e)