### PR TITLE
Restore image-based share links and preserve slide titles

### DIFF
--- a/index.html
+++ b/index.html
@@ -1589,15 +1589,19 @@
         const title = s.querySelector('.art-title')?.textContent?.trim() || 'Artwork';
         const artworkSlug = slugify(title);
 
-        const shareUrl = new URL(window.location.href);
-        shareUrl.searchParams.set('art', artworkSlug);
-        shareUrl.hash = '';
+        const imageEl = s.querySelector('.zoom-container img');
+        const imageSrc = imageEl?.getAttribute('src');
+        if (!imageSrc) return;
+
+        const imageUrl = new URL(imageSrc, window.location.origin);
+        imageUrl.hash = artworkSlug;
 
         try {
           if (navigator.share) {
             const shareData = {
               title,
-              url: shareUrl.href
+              text: title,
+              url: imageUrl.href
             };
 
             await navigator.share(shareData);
@@ -1608,7 +1612,8 @@
           if (err && err.name === 'AbortError') return;
         }
 
-        await navigator.clipboard.writeText(shareUrl.href);
+        await navigator.clipboard.writeText(`${title}
+${imageUrl.href}`);
         showShareFeedback('Link copied to clipboard');
       }
 


### PR DESCRIPTION
### Motivation
- A recent change switched the mobile share payload to the page URL, which broke expected behavior by sending the base site link instead of the direct artwork image and removed the previous combined title+image clipboard fallback. 
- The intent is to keep human-readable slide titles (e.g. `Mouth Full of Matches`) while restoring the previous behavior of sharing the actual artwork image URL.

### Description
- Reworked `handleShare()` to read the image element from the slide (`.zoom-container img`) and construct `imageUrl` with the artwork slug in the hash. 
- Set the Web Share `shareData` to include `title` (and `text: title`) while using `url: imageUrl.href` so recipients receive the direct image link with the slide title. 
- Restored the clipboard fallback to copy both the artwork `title` and the direct `imageUrl.href` (newline-separated). 
- Left slide-title sourcing via `.art-title` and slug generation via `slugify(title)` intact.

### Testing
- Verified relevant code and history with `rg -n "share|navigator.share|title|MouthfullOfMatches|Mouth Full of Matches" -S .` and `git show` to inspect the prior change, which succeeded. 
- Confirmed the updated diff with `git diff -- index.html` and inspected the updated lines with `nl -ba index.html | sed -n '1584,1618p'`, which show `shareData.url` now set to `imageUrl.href` and the clipboard fallback restored. 
- Committed the fix locally with `git commit -m "Restore image share URL while keeping artwork title"`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6b5a07d8833399c49f3a813ce029)