### PR TITLE
Add gallery slides for additional image/audio asset pairs

### DIFF
--- a/index.html
+++ b/index.html
@@ -987,6 +987,102 @@
           </div>
         </div>
 
+        <div class="slide">
+          <div class="zoom-container">
+            <img loading="lazy" src="assets/images/cork.jpeg" alt="Cork City" />
+          </div>
+          <div class="slide-info">
+            <h2 class="art-title">Cork City</h2>
+            <p class="artist">by Suzanne O'Shea</p>
+            <p class="art-description">
+              A portrait of presence and place, where urban memory and inner weather
+              blend into one vivid atmosphere.
+            </p>
+            <div class="art-details">
+              <p class="art-dimensions">Mixed Dimensions</p>
+              <p class="art-medium">Mixed Media</p>
+            </div>
+            <button class="play-audio" data-src="assets/audio/cork-city.mp3" aria-label="Play audio">
+              <svg width="18" height="18" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="24" cy="24" r="22" stroke="black" stroke-width="2" fill="white" />
+                <polygon points="18,14 34,24 18,34" fill="black" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="slide">
+          <div class="zoom-container">
+            <img loading="lazy" src="assets/images/enigma.jpeg" alt="Enigma" />
+          </div>
+          <div class="slide-info">
+            <h2 class="art-title">Enigma</h2>
+            <p class="artist">by Suzanne O'Shea</p>
+            <p class="art-description">
+              A layered gaze that withholds and reveals at once, inviting the viewer
+              to stay inside the mystery.
+            </p>
+            <div class="art-details">
+              <p class="art-dimensions">Mixed Dimensions</p>
+              <p class="art-medium">Mixed Media</p>
+            </div>
+            <button class="play-audio" data-src="assets/audio/enigma.mp3" aria-label="Play audio">
+              <svg width="18" height="18" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="24" cy="24" r="22" stroke="black" stroke-width="2" fill="white" />
+                <polygon points="18,14 34,24 18,34" fill="black" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="slide">
+          <div class="zoom-container">
+            <img loading="lazy" src="assets/images/jester.jpeg" alt="Jester's Muse" />
+          </div>
+          <div class="slide-info">
+            <h2 class="art-title">Jester's Muse</h2>
+            <p class="artist">by Suzanne O'Shea</p>
+            <p class="art-description">
+              Equal parts wit and ache, this figure carries theatrical color like
+              armor, daring joy to coexist with shadow.
+            </p>
+            <div class="art-details">
+              <p class="art-dimensions">Mixed Dimensions</p>
+              <p class="art-medium">Mixed Media</p>
+            </div>
+            <button class="play-audio" data-src="assets/audio/jesters-muse.mp3" aria-label="Play audio">
+              <svg width="18" height="18" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="24" cy="24" r="22" stroke="black" stroke-width="2" fill="white" />
+                <polygon points="18,14 34,24 18,34" fill="black" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="slide">
+          <div class="zoom-container">
+            <img loading="lazy" src="assets/images/mothers-of.jpg" alt="Mothers of Ukraine" />
+          </div>
+          <div class="slide-info">
+            <h2 class="art-title">Mothers of Ukraine</h2>
+            <p class="artist">by Suzanne O'Shea</p>
+            <p class="art-description">
+              A tribute to endurance and fierce tenderness, where grief and courage
+              stand side by side.
+            </p>
+            <div class="art-details">
+              <p class="art-dimensions">Mixed Dimensions</p>
+              <p class="art-medium">Mixed Media</p>
+            </div>
+            <button class="play-audio" data-src="assets/audio/mothers-of-ukraine.mp3" aria-label="Play audio">
+              <svg width="18" height="18" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="24" cy="24" r="22" stroke="black" stroke-width="2" fill="white" />
+                <polygon points="18,14 34,24 18,34" fill="black" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
       <div class="slideshow-nav">
         <button id="prevBtn" class="btn-prev" type="button">Prev</button>
         <button id="nextBtn" class="btn-next" type="button">Next</button>


### PR DESCRIPTION
### Motivation
- Include unused artwork image files in the interactive gallery so each asset has a visible slide. 
- Ensure each newly-added slide is paired with its corresponding audio file so visitors can play the matching narration/music. 

### Description
- Added four new `.slide` entries to `index.html` for `cork.jpeg`, `enigma.jpeg`, `jester.jpeg`, and `mothers-of.jpg`, each with title, artist line, description, details, and an audio play button. 
- Each new slide's play button is wired to the matching audio file: `cork-city.mp3`, `enigma.mp3`, `jesters-muse.mp3`, and `mothers-of-ukraine.mp3`. 
- No changes were required to the slideshow or audio playback JavaScript because the existing code already discovers and handles all `.slide` and `.play-audio` elements. 

### Testing
- Ran a Python check to list unused images and audio and confirm matching filename candidates, which succeeded. 
- Verified mappings between image filenames and audio filenames via a normalization script, which succeeded. 
- Inspected the updated `index.html` fragment with `nl`/`sed` to confirm the slides were added inside the slideshow container before navigation controls, which succeeded. 
- Committed the change (`git commit`) and prepared the PR message with `make_pr`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7107ff4c83338593ba8fa16564bd)