### PR TITLE
Enable audio on Mouth Full of Matches slide

### DIFF
--- a/index.html
+++ b/index.html
@@ -897,14 +897,14 @@
           <p class="artist">by Suzanne O'Shea</p>
           <p class="art-description">
             Arms crossed and gaze unwavering, the figure stands within layers of heat, shadow, and fractured light.
-            A Mouth Full of Matches evokes what remains after ignition, not destruction, but endurance. Vivid reds and
-            smoky textures suggest a woman shaped by intensity, holding both vulnerability and defiant presence.
+            It evokes what remains after ignition, not destruction, but endurance. Vivid reds and smoky textures suggest
+            a woman shaped by intensity, holding both vulnerability and defiant presence.
           </p>
           <div class="art-details">
             <p class="art-dimensions">24" x 18"</p>
             <p class="art-medium">Mixed Media</p>
           </div>
-          <button class="play-audio" style="visibility: hidden;" aria-label="Play audio">
+          <button class="play-audio" data-src="assets/audio/MouthFull.mp3" aria-label="Play audio">
             <svg width="18" height="18" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
               <circle cx="24" cy="24" r="22" stroke="black" stroke-width="2" fill="white" />
               <polygon points="18,14 34,24 18,34" fill="black" />
@@ -1142,6 +1142,7 @@
     <audio preload="metadata" src="assets/audio/jesters-muse.wav"></audio>
     <audio preload="metadata" src="assets/audio/mind-games.mp3"></audio>
     <audio preload="metadata" src="assets/audio/mind-games.wav"></audio>
+    <audio preload="metadata" src="assets/audio/MouthFull.mp3"></audio>
     <audio preload="metadata" src="assets/audio/mothers-of-ukraine.wav"></audio>
     <audio preload="metadata" src="assets/audio/peace-out.mp3"></audio>
     <audio preload="metadata" src="assets/audio/peace-out.wav"></audio>


### PR DESCRIPTION
### Motivation
- Make the Mouth Full of Matches slide playable and fit the shorter requested description so the audio asset is available to visitors and the copy matches layout constraints.

### Description
- Wired the slide's play button to `assets/audio/MouthFull.mp3` and removed the `visibility: hidden` style so the button is visible and usable.
- Replaced the slide description with the provided shorter copy.
- Added a preload entry for `assets/audio/MouthFull.mp3` in `index.html` to match existing audio preload behavior.

### Testing
- Verified the updated markup and audio preload entry in `index.html` and committed the change, and there is no automated test suite configured for this repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff84cc20748333b22853629fe2af14)