### PR TITLE
Reduce gallery footer fade to prevent audio button clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -522,7 +522,7 @@
       bottom: 0;
       left: 0;
       width: 100%;
-      height: 60px;
+      height: 58px;
       background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.5));
       z-index: 1002;
     }


### PR DESCRIPTION
### Motivation
- The bottom gallery fade was slightly overlapping the slide footer and clipping the `play-audio` button on the "Mouth Full of Matches" slide, so the overlay needs to be reduced by a pixel or two to give the control a little more room.

### Description
- Adjusted the inline CSS in `index.html` to change `.gallery-screen::after` height from `60px` to `58px` so the bottom fade is slightly smaller and the audio button has more visible space.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8feff2a08333bc4bfc5e0aac98e2)